### PR TITLE
Expose date header for -cors

### DIFF
--- a/gpac-dash.js
+++ b/gpac-dash.js
@@ -400,6 +400,7 @@ var onRequest = function(req, res) {
 
 	if (allowCors) {
 		res.setHeader("Access-Control-Allow-Origin", "*");
+		res.setHeader("Access-Control-Expose-Headers", "Date");
 	}
 
 	// we send the files as they come, except for segments for which we send fragment by fragment


### PR DESCRIPTION
dash.js can use the date header for time sync, but it doesn't get through when cross origin.
